### PR TITLE
Remove OpenAL library references

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -64,7 +64,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
 
-    <EmbeddedNativeLibrary Include="..\ThirdParty\Dependencies\openal-soft\libs\armeabi-v7a\libopenal32.so">
+    <!-- <EmbeddedNativeLibrary Include="..\ThirdParty\Dependencies\openal-soft\libs\armeabi-v7a\libopenal32.so">
       <Platforms>Android,Ouya</Platforms>
       <Link>libs\armeabi-v7a\libopenal32.so</Link>
     </EmbeddedNativeLibrary>
@@ -75,7 +75,7 @@
     <EmbeddedNativeLibrary Include="..\ThirdParty\Dependencies\openal-soft\libs\x86\libopenal32.so">
       <Platforms>Android,Ouya</Platforms>
       <Link>libs\x86\libopenal32.so</Link>
-    </EmbeddedNativeLibrary>
+    </EmbeddedNativeLibrary> -->
 
     <!-- Microsoft.Xna.Framework -->
     <Compile Include="BoundingBox.cs" />


### PR DESCRIPTION
This is a temporary hack fixing an issue caused by dupplicate OpenAL library being added during the BuildApk task
