### PR TITLE
Test if texture name is not -1 before binding.

### DIFF
--- a/MonoGame.Framework/Graphics/SamplerStateCollection.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/SamplerStateCollection.OpenGL.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 var sampler = _samplers[i];
                 var texture = device.Textures[i];
 
-                if (sampler != null && texture != null)
+                if (sampler != null && texture != null && texture.glTexture != -1)
                 {
                     SamplerState lastSampler = null;
                     texture.glLastSamplerStates.TryGetValue(i, out lastSampler);

--- a/MonoGame.Framework/Graphics/TextureCollection.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.cs
@@ -131,8 +131,11 @@ namespace Microsoft.Xna.Framework.Graphics
                 if (tex != null)
                 {
                     _targets[i] = tex.glTarget;
-                    GL.BindTexture(tex.glTarget, tex.glTexture);
-                    GraphicsExtensions.CheckGLError();
+                    if (tex.glTexture != -1)
+                    {
+                        GL.BindTexture(tex.glTarget, tex.glTexture);
+                        GraphicsExtensions.CheckGLError();
+                    }
                 }
 #elif DIRECTX
                 if (_textures[i] == null || _textures[i].IsDisposed)


### PR DESCRIPTION
As -1 seems to be the name MG uses to mark deleted texture,this should be ok.
