### PR TITLE
DO NOT MERGE, this is for discussion only.

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -765,7 +765,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 
             var posFixupLoc = shaderProgram.GetUniformLocation("posFixup");
-            if (posFixupLoc == -1)
+            if (posFixupLoc == null)
                 return;
 
             // Apply vertex shader fix:
@@ -807,7 +807,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 _posFixup[3] *= -1.0f;
             }
 
-            GL.Uniform4(posFixupLoc, 1, _posFixup);
+            GL.Uniform4(posFixupLoc.location, 1, _posFixup);
             GraphicsExtensions.CheckGLError();
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -880,6 +880,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
             Textures.SetTextures(this);
             SamplerStates.PlatformSetSamplers(this);
+
+            _vertexConstantBuffers.Clear();
+            _pixelConstantBuffers.Clear();
         }
 
         private void PlatformDrawIndexedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount)

--- a/MonoGame.Framework/Graphics/Shader/ConstantBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Shader/ConstantBuffer.OpenGL.cs
@@ -17,9 +17,7 @@ namespace Microsoft.Xna.Framework.Graphics
     internal partial class ConstantBuffer
     {
         private ShaderProgram _shaderProgram = null;
-        private int _location;
-
-        static ConstantBuffer[] _lastConstantBufferApplied = new ConstantBuffer[1024];
+        private ShaderLocation _shaderLocation = null;
 
         /// <summary>
         /// A hash value which can be used to compare constant buffers.
@@ -55,19 +53,19 @@ namespace Microsoft.Xna.Framework.Graphics
             // uniform again and apply the state.
             if (_shaderProgram != program)
             {
-                _location = program.GetUniformLocation(_name);
+                _shaderLocation = program.GetUniformLocation(_name);
                 _shaderProgram = program;
                 _dirty = true;
             }
 
-            if (_location == -1)
+            if (_shaderLocation == null)
                 return;
 
             // If the shader program is the same, the effect may still be different and have different values in the buffer
             // this is not working should be a per location cache.
             //if (!Object.ReferenceEquals(this, _lastConstantBufferApplied))
             //    _dirty = true;
-            if (!Object.ReferenceEquals(this, _lastConstantBufferApplied[_location]))
+            if (!Object.ReferenceEquals(this, _shaderLocation.lastConstantBufferApplied))
                 _dirty = true;
 
             // If the buffer content hasn't changed then we're
@@ -81,7 +79,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 // and cast this correctly... else it doesn't work as i guess
                 // GL is checking the type of the uniform.
 
-                GL.Uniform4(_location, _buffer.Length / 16, (float*)bytePtr);
+                GL.Uniform4(_shaderLocation.location, _buffer.Length / 16, (float*)bytePtr);
                 GraphicsExtensions.CheckGLError();
             }
 
@@ -89,7 +87,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _dirty = false;
 
             // per location cache
-            _lastConstantBufferApplied[_location] = this;
+            _shaderLocation.lastConstantBufferApplied = this;
         }
     }
 }

--- a/MonoGame.Framework/Graphics/Shader/ConstantBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Shader/ConstantBuffer.OpenGL.cs
@@ -55,14 +55,13 @@ namespace Microsoft.Xna.Framework.Graphics
             // uniform again and apply the state.
             if (_shaderProgram != program)
             {
-                var location = program.GetUniformLocation(_name);
-                if (location == -1)
-                    return;
-
+                _location = program.GetUniformLocation(_name);
                 _shaderProgram = program;
-                _location = location;
                 _dirty = true;
             }
+
+            if (_location == -1)
+                return;
 
             // If the shader program is the same, the effect may still be different and have different values in the buffer
             if (!Object.ReferenceEquals(this, _lastConstantBufferApplied))

--- a/MonoGame.Framework/Graphics/Shader/ConstantBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Shader/ConstantBuffer.OpenGL.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private ShaderProgram _shaderProgram = null;
         private int _location;
 
-        static ConstantBuffer _lastConstantBufferApplied = null;
+        static ConstantBuffer[] _lastConstantBufferApplied = new ConstantBuffer[1024];
 
         /// <summary>
         /// A hash value which can be used to compare constant buffers.
@@ -64,7 +64,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 return;
 
             // If the shader program is the same, the effect may still be different and have different values in the buffer
-            if (!Object.ReferenceEquals(this, _lastConstantBufferApplied))
+            // this is not working should be a per location cache.
+            //if (!Object.ReferenceEquals(this, _lastConstantBufferApplied))
+            //    _dirty = true;
+            if (!Object.ReferenceEquals(this, _lastConstantBufferApplied[_location]))
                 _dirty = true;
 
             // If the buffer content hasn't changed then we're
@@ -85,7 +88,8 @@ namespace Microsoft.Xna.Framework.Graphics
             // Clear the dirty flag.
             _dirty = false;
 
-            _lastConstantBufferApplied = this;
+            // per location cache
+            _lastConstantBufferApplied[_location] = this;
         }
     }
 }

--- a/MonoGame.Framework/Graphics/Shader/ConstantBufferCollection.cs
+++ b/MonoGame.Framework/Graphics/Shader/ConstantBufferCollection.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Xna.Framework.Graphics
             get { return _buffers[index]; }
             set
             {
-                if (_buffers[index] == value)
-                    return;
+                //if (_buffers[index] == value)
+                //    return;
 
                 if (value != null)
                 {
@@ -65,7 +65,7 @@ namespace Microsoft.Xna.Framework.Graphics
             if (_valid == 0)
                 return;
 
-            var valid = _valid;
+            //var valid = _valid;
 
             for (var i = 0; i < _buffers.Length; i++)
             {
@@ -80,8 +80,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
 
                 // Early out if this is the last one.
-                valid &= ~(1 << i);
-                if (valid == 0)
+                _valid &= ~(1 << i);
+                if (_valid == 0)
                     return;
             }
         }

--- a/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
+++ b/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
@@ -21,27 +21,44 @@ using GetProgramParameterName = OpenTK.Graphics.ES20.All;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    internal class ShaderLocation
+    {
+        internal int location;
+        internal ConstantBuffer lastConstantBufferApplied;
+
+        public ShaderLocation(int location)
+        {
+            this.location = location;
+        }
+    };
 
     internal class ShaderProgram
     {
         public readonly int Program;
 
-        private readonly Dictionary<string, int> _uniformLocations = new Dictionary<string, int>();
+        private readonly Dictionary<string, ShaderLocation> _uniformLocations = new Dictionary<string, ShaderLocation>();
 
         public ShaderProgram(int program)
         {
             Program = program;
         }
 
-        public int GetUniformLocation(string name)
+        public ShaderLocation GetUniformLocation(string name)
         {
-            if (_uniformLocations.ContainsKey(name))
-                return _uniformLocations[name];
+            ShaderLocation shaderLocation = null;
+            if (_uniformLocations.TryGetValue(name, out shaderLocation))
+            { return shaderLocation; }
 
-            var location = GL.GetUniformLocation(Program, name);
+            int location = GL.GetUniformLocation(Program, name);
             GraphicsExtensions.CheckGLError();
-            _uniformLocations[name] = location;
-            return location;
+
+            if (location != -1)
+            {
+                shaderLocation = new ShaderLocation(location);
+            }
+
+            _uniformLocations[name] = shaderLocation;
+            return shaderLocation;
         }
     }
 


### PR DESCRIPTION
Fix : ConstantBuffer cache flawed design
These 3 changes address the same issue : uploading a contant buffer of a previous shader to the current shader.

MojoShader groups uniforms per shader (vs/ps) typed constant buffers. A vs or a ps can have 3 distincts contant buffers : vs/ps _uniform_vec4, vs/ps_uniform_ivec4, vs/ps_uniform_bool. 

In our shaders we only use vs_uniform_vec4 and ps_uniform_vec4,

Use case where it breaks :
Shader A : vs_uniform_vec4, ps_uniform_vec4
Shader B : vs_uniform_vec4 (no ps uniforms)

Bind and draw with Shader A : we'll upload vs and ps constant buffers.
Bind and draw with Shader B : we'll upload vs constant buffer + the previous ps constant buffer remaining in the cache => MG will try to find the location of the ps_uniform_vec4, triggering unwanted GL.GetUniformLocation each time since it meets another flaw (ConstantBuffer.Opengl.cs don't store failure and try to find the location even if it has previously failed for the same shader and uniform).

We can fix this by :
1) Clear the constant buffer cache after each draw call (GraphicsDevice.OpenGL.cs)
2) Unflag _valid constant buffers when they are uploaded and flag them _valid when set to the collection even if they're equals (We can think it'll trigger extra reupload but since the _valid is never unflaged, they're already always reuploaded).
3) Store when we failed to GL.GetUniformLocation for a shader, so that we don't try again.

I think the best is 2)

PS : found another issue while writing this, the cbuffer cache is marking dirty each contant buffer.
Shader C : vs_uniform_vec4, ps_uniform_vec4
a) Apply Vertex Constant buffers : comparing vs_uniform_vec4 against static _lastContantBufferApplied, apply if changed + storing this cbuffer in _lastConstantBufferApplied.
b) Apply Pixel Constant buffers :  comparing ps_uniform_vec4 against static _lastContantBufferApplied (not working)
c) Draw.

It should be a per uniform location, cache 
