### PR TITLE
Fix : Per uniform location, constant buffer cache.

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -765,7 +765,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 
             var posFixupLoc = shaderProgram.GetUniformLocation("posFixup");
-            if (posFixupLoc == -1)
+            if (posFixupLoc == null)
                 return;
 
             // Apply vertex shader fix:
@@ -807,7 +807,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 _posFixup[3] *= -1.0f;
             }
 
-            GL.Uniform4(posFixupLoc, 1, _posFixup);
+            GL.Uniform4(posFixupLoc.location, 1, _posFixup);
             GraphicsExtensions.CheckGLError();
         }
 

--- a/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
+++ b/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
@@ -21,27 +21,48 @@ using GetProgramParameterName = OpenTK.Graphics.ES20.All;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    internal class ShaderLocation
+    {
+        internal int location;
+        internal ConstantBuffer lastConstantBufferApplied;
+
+        public ShaderLocation(int location)
+        {
+            this.location = location;
+        }
+    };
 
     internal class ShaderProgram
     {
         public readonly int Program;
 
-        private readonly Dictionary<string, int> _uniformLocations = new Dictionary<string, int>();
+        private readonly Dictionary<string, ShaderLocation> _uniformLocations = new Dictionary<string, ShaderLocation>();
 
         public ShaderProgram(int program)
         {
             Program = program;
         }
 
-        public int GetUniformLocation(string name)
+        public ShaderLocation GetUniformLocation(string name)
+        {
+            ShaderLocation shaderLocation = null;
+            if (_uniformLocations.TryGetValue(name, out shaderLocation))
+            { return shaderLocation; }
+
+            int location = GL.GetUniformLocation(Program, name);
+            GraphicsExtensions.CheckGLError();
+
+            if (location != -1)
+            { shaderLocation = new ShaderLocation(location); }
+
+            _uniformLocations[name] = shaderLocation;
+            return shaderLocation;
+        }
+
+        public void ClearUniformLocation(string name)
         {
             if (_uniformLocations.ContainsKey(name))
-                return _uniformLocations[name];
-
-            var location = GL.GetUniformLocation(Program, name);
-            GraphicsExtensions.CheckGLError();
-            _uniformLocations[name] = location;
-            return location;
+            { _uniformLocations.Remove(name); }
         }
     }
 


### PR DESCRIPTION
 The constant buffer cache is always dirty since it's checking against the last constant buffer applied regardless of the location.
