### PR TITLE
Fix : The constant buffer cache is always dirty.

### DIFF
--- a/MonoGame.Framework/Graphics/Shader/ConstantBufferCollection.cs
+++ b/MonoGame.Framework/Graphics/Shader/ConstantBufferCollection.cs
@@ -29,9 +29,6 @@ namespace Microsoft.Xna.Framework.Graphics
             get { return _buffers[index]; }
             set
             {
-                if (_buffers[index] == value)
-                    return;
-
                 if (value != null)
                 {
                     _buffers[index] = value;
@@ -65,8 +62,6 @@ namespace Microsoft.Xna.Framework.Graphics
             if (_valid == 0)
                 return;
 
-            var valid = _valid;
-
             for (var i = 0; i < _buffers.Length; i++)
             {
                 var buffer = _buffers[i];
@@ -80,8 +75,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
 
                 // Early out if this is the last one.
-                valid &= ~(1 << i);
-                if (valid == 0)
+                _valid &= ~(1 << i);
+                if (_valid == 0)
                     return;
             }
         }


### PR DESCRIPTION
The constant buffer cache is always dirty, so we end up trying to upload uniforms on a shaders where they do not exists.

Draw with Shader A : uploading vs_uniform_A and ps_uniform_A
Draw with Shader B (no ps uniforms) : uploading vs_uniform_B but, we'll still try to upload ps_uniform_A.
