### PR TITLE
React to resolution changes on Android (like immersive mode)

### DIFF
--- a/MonoGame.Framework/Android/AndroidGameWindow.cs
+++ b/MonoGame.Framework/Android/AndroidGameWindow.cs
@@ -182,8 +182,11 @@ namespace Microsoft.Xna.Framework
         
         internal void ChangeClientBounds(Rectangle bounds)
         {
-            _clientBounds = bounds;
-            OnClientSizeChanged();
+            if (bounds != _clientBounds)
+            {
+                _clientBounds = bounds;
+                OnClientSizeChanged();
+            }
         }
 
         public override bool AllowUserResizing 

--- a/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
@@ -91,6 +91,18 @@ namespace Microsoft.Xna.Framework
                 }
             }
 
+            var manager = _game.graphicsDeviceManager;
+            
+            manager.PreferredBackBufferWidth = width;
+            manager.PreferredBackBufferHeight = height;
+
+            if (manager.GraphicsDevice != null)
+                manager.GraphicsDevice.Viewport = new Viewport(0, 0, width, height);
+
+            _gameWindow.ChangeClientBounds(new Rectangle(0, 0, width, height));
+
+            manager.ApplyChanges();
+
             SurfaceChanged(holder, format, width, height);
             Android.Util.Log.Debug("MonoGame", "MonoGameAndroidGameView.SurfaceChanged: format = " + format + ", width = " + width + ", height = " + height);
 


### PR DESCRIPTION
Cherry picked a commit that allows monogame to trigger a OnClientSizeChanged() event on android when the software buttons get hidden in immersive mode.
