### PR TITLE
Fixes a logical buffer store operation (iOS) when swapping the defaul…

### DIFF
--- a/MonoGame.Framework/iOS/iOSGameView.cs
+++ b/MonoGame.Framework/iOS/iOSGameView.cs
@@ -217,12 +217,28 @@ namespace Microsoft.Xna.Framework {
 
 			_glapi.GenFramebuffers (1, ref _framebuffer);
 			_glapi.BindFramebuffer (All.Framebuffer, _framebuffer);
-			
+
 			// Create our Depth buffer. Color buffer must be the last one bound
-			GL.GenRenderbuffers(1, out _depthbuffer);
-			GL.BindRenderbuffer(RenderbufferTarget.Renderbuffer, _depthbuffer);
-            GL.RenderbufferStorage(RenderbufferTarget.Renderbuffer, RenderbufferInternalFormat.DepthComponent16, viewportWidth, viewportHeight);
-			GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferSlot.DepthAttachment, RenderbufferTarget.Renderbuffer, _depthbuffer);
+            var gdm = _platform.Game.Services.GetService(
+                typeof(IGraphicsDeviceManager)) as GraphicsDeviceManager;
+            if (gdm != null)
+            {
+                var preferredDepthFormat = gdm.PreferredDepthStencilFormat;
+                if (preferredDepthFormat != DepthFormat.None)
+                {
+                    GL.GenRenderbuffers(1, out _depthbuffer);
+                    GL.BindRenderbuffer(RenderbufferTarget.Renderbuffer, _depthbuffer);
+                    var internalFormat = All.DepthComponent16;
+                    if (preferredDepthFormat == DepthFormat.Depth24)
+                        internalFormat = All.DepthComponent24Oes;
+                    else if (preferredDepthFormat == DepthFormat.Depth24Stencil8)
+                        internalFormat = All.Depth24Stencil8Oes;
+                    GL.RenderbufferStorage(RenderbufferTarget.Renderbuffer, (RenderbufferInternalFormat)internalFormat, viewportWidth, viewportHeight);
+                    GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferSlot.DepthAttachment, RenderbufferTarget.Renderbuffer, _depthbuffer);
+                    if (preferredDepthFormat == DepthFormat.Depth24Stencil8)
+                        GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferSlot.StencilAttachment, RenderbufferTarget.Renderbuffer, _depthbuffer);
+                }
+            }
 
 			_glapi.GenRenderbuffers(1, ref _colorbuffer);
 			_glapi.BindRenderbuffer(All.Renderbuffer, _colorbuffer);
@@ -299,9 +315,14 @@ namespace Microsoft.Xna.Framework {
 			_glapi.DeleteRenderbuffers (1, ref _colorbuffer);
 			_colorbuffer = 0;
 			
-			_glapi.DeleteRenderbuffers (1, ref _depthbuffer);
-			_depthbuffer = 0;
+            if (_depthbuffer != 0)
+            {
+			    _glapi.DeleteRenderbuffers (1, ref _depthbuffer);
+			    _depthbuffer = 0;
+            }
 		}
+
+        private static readonly All[] attachements = new All[] { All.DepthAttachment, All.StencilAttachment };
 
 		// FIXME: This logic belongs in GraphicsDevice.Present, not
 		//        here.  If it can someday be moved there, then the
@@ -314,7 +335,8 @@ namespace Microsoft.Xna.Framework {
             AssertValidContext ();
 
             this.MakeCurrent();
-            GL.BindRenderbuffer (All.Renderbuffer, this._colorbuffer);
+            GL.BindRenderbuffer(RenderbufferTarget.Renderbuffer, this._colorbuffer);
+            GraphicsDevice.FramebufferHelper.GLDiscardFramebufferExt(All.Framebuffer, 2, attachements);
             __renderbuffergraphicsContext.SwapBuffers();
 		}
 


### PR DESCRIPTION
…t framebuffer

Discards the depth/stencil attached to the main framebuffer (if any) to avoid a logical buffer store operation when the main framebuffer is swapped.
This also adds proper depth/stencil initialization based on the value of `GraphicsDeviceManager.PreferredDepthFormat`.
