### PR TITLE
Fixed VertexDeclaration Cache issues.

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -855,7 +855,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			var target = PrimitiveTypeGL(primitiveType);
 			var vertexOffset = (IntPtr)(_vertexBuffer.VertexDeclaration.VertexStride * baseVertex);
 
-			_vertexBuffer.VertexDeclaration.Apply(_vertexShader, vertexOffset);
+			_vertexBuffer.VertexDeclaration.Apply(_vertexShader, _pixelShader, vertexOffset);
 
             GL.DrawElements(target,
                                      indexElementCount,
@@ -880,7 +880,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Setup the vertex declaration to point at the VB data.
             vertexDeclaration.GraphicsDevice = this;
-            vertexDeclaration.Apply(_vertexShader, vbHandle.AddrOfPinnedObject());
+            vertexDeclaration.Apply(_vertexShader, _pixelShader, vbHandle.AddrOfPinnedObject());
 
             //Draw
             GL.DrawArrays(PrimitiveTypeGL(primitiveType),
@@ -907,7 +907,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Setup the vertex declaration to point at the VB data.
             vertexDeclaration.GraphicsDevice = this;
-            vertexDeclaration.Apply(_vertexShader, vertexAddr);
+            vertexDeclaration.Apply(_vertexShader, _pixelShader, vertexAddr);
 
             //Draw
             GL.DrawArrays(PrimitiveTypeGL(primitiveType), vertexOffset, vertexCount);
@@ -918,7 +918,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             PlatformApplyState(true);
 
-            _vertexBuffer.VertexDeclaration.Apply(_vertexShader, IntPtr.Zero);
+            _vertexBuffer.VertexDeclaration.Apply(_vertexShader, _pixelShader, IntPtr.Zero);
 
 			GL.DrawArrays(PrimitiveTypeGL(primitiveType),
 			              vertexStart,
@@ -945,7 +945,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Setup the vertex declaration to point at the VB data.
             vertexDeclaration.GraphicsDevice = this;
-            vertexDeclaration.Apply(_vertexShader, vertexAddr);
+            vertexDeclaration.Apply(_vertexShader, _pixelShader, vertexAddr);
 
             //Draw
             GL.DrawElements(    PrimitiveTypeGL(primitiveType),
@@ -978,7 +978,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Setup the vertex declaration to point at the VB data.
             vertexDeclaration.GraphicsDevice = this;
-            vertexDeclaration.Apply(_vertexShader, vertexAddr);
+            vertexDeclaration.Apply(_vertexShader, _pixelShader, vertexAddr);
 
             //Draw
             GL.DrawElements(    PrimitiveTypeGL(primitiveType),
@@ -1007,7 +1007,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Setup the vertex declaration to point at the VB data.
             vertexDeclaration.GraphicsDevice = this;
-            vertexDeclaration.Apply(_vertexShader, vertexAddr);
+            vertexDeclaration.Apply(_vertexShader, _pixelShader, vertexAddr);
 
             //Draw
             GL.DrawElements(PrimitiveTypeGL(primitiveType),

--- a/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.OpenGL.cs
@@ -19,10 +19,10 @@ namespace Microsoft.Xna.Framework.Graphics
     {
         Dictionary<int, VertexDeclarationAttributeInfo> shaderAttributeInfo = new Dictionary<int, VertexDeclarationAttributeInfo>();
 
-		internal void Apply(Shader shader, IntPtr offset)
+		internal void Apply(Shader vertexShader, Shader pixelShader, IntPtr offset)
 		{
             VertexDeclarationAttributeInfo attrInfo;
-            int shaderHash = shader.GetHashCode();
+            int shaderHash = vertexShader.HashKey | pixelShader.HashKey;
             if (!shaderAttributeInfo.TryGetValue(shaderHash, out attrInfo))
             {
                 // Get the vertex attribute info and cache it
@@ -30,7 +30,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 foreach (var ve in _elements)
                 {
-                    var attributeLocation = shader.GetAttribLocation(ve.VertexElementUsage, ve.UsageIndex);
+                    var attributeLocation = vertexShader.GetAttribLocation(ve.VertexElementUsage, ve.UsageIndex);
                     // XNA appears to ignore usages it can't find a match for, so we will do the same
                     if (attributeLocation >= 0)
                     {


### PR DESCRIPTION
Depending on which pixel shader is linked to a particular vertex shader, the DX/Mojo optimisation pass could lead to different vertex declarations,
hence we cannot only rely on the vertex shader source code hash to ensure unicity of the vertex declarations.