### PR TITLE
Fixed using shader program before checking link status

### DIFF
--- a/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
+++ b/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
@@ -134,13 +134,6 @@ namespace Microsoft.Xna.Framework.Graphics
             GL.LinkProgram(program);
             GraphicsExtensions.CheckGLError();
 
-            GL.UseProgram(program);
-            GraphicsExtensions.CheckGLError();
-
-            vertexShader.GetVertexAttributeLocations(program);
-
-            pixelShader.ApplySamplerTextureUnits(program);
-
             var linked = 0;
 
             GL.GetProgram(program, GetProgramParameterName.LinkStatus, out linked);
@@ -158,6 +151,14 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
                 throw new InvalidOperationException("Unable to link effect program" + (String.IsNullOrEmpty(log) ? "" : (": " + log)));
             }
+
+            GL.UseProgram(program);
+            GraphicsExtensions.CheckGLError();
+
+            vertexShader.GetVertexAttributeLocations(program);
+
+            pixelShader.ApplySamplerTextureUnits(program);
+
 
             ShaderProgram shaderProgram = new ShaderProgram(program);
 


### PR DESCRIPTION
glUseProgram was called before checking the link status of  glLinkProgram.
This would result in a crash with no log information when the link was not successful.