### PR TITLE
Reduce the number of vertex declaration setups

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private Rectangle _scissorRectangle;
         private bool _scissorRectangleDirty;
   
-        private VertexBuffer _vertexBuffer;
+        internal VertexBuffer _vertexBuffer;
         private bool _vertexBufferDirty;
 
         private IndexBuffer _indexBuffer;

--- a/MonoGame.Framework/Graphics/Model.cs
+++ b/MonoGame.Framework/Graphics/Model.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Deployment.Internal;
 using System.Linq;
-using System.Web.UI.WebControls.WebParts;
-using System.Xml.XPath;
 
 namespace Microsoft.Xna.Framework.Graphics
 {

--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Xna.Framework.Graphics
     public partial class IndexBuffer : GraphicsResource
     {
         private readonly bool _isDynamic;
+        public byte[] _data;
 
         public BufferUsage BufferUsage { get; private set; }
         public int IndexCount { get; private set; }
@@ -110,6 +111,11 @@ namespace Microsoft.Xna.Framework.Graphics
         public void SetData<T>(T[] data) where T : struct
         {
             SetDataInternal<T>(0, data, 0, data.Length, SetDataOptions.None);
+        }
+        public void SetData(byte[] data)
+        {
+            _data = data;
+            SetDataInternal<byte>(0, data, 0, data.Length, SetDataOptions.None);
         }
 
         protected void SetDataInternal<T>(int offsetInBytes, T[] data, int startIndex, int elementCount, SetDataOptions options) where T : struct


### PR DESCRIPTION
- Add a cache of vertex declarations.
- Add method to regenerate the index buffers of a model with full indices (instead of relying on the offset parameter of glVertexAttribPointer).
